### PR TITLE
Fix indian rupee currency formatting in quickview.js

### DIFF
--- a/FastOrder/view/frontend/web/js/enhanced-product-ui.js
+++ b/FastOrder/view/frontend/web/js/enhanced-product-ui.js
@@ -193,7 +193,7 @@ define([
         });
     }
 
-    function updateRowSubtotal($row) {
+        function updateRowSubtotal($row) {
         const qty = parseFloat($row.find('input[type="number"]').val()) || 0;
         const ptr = parseFloat($row.find('.wrapPtr__As8_S__fast_order').text()) || 0;
         const discount = parseFloat($row.find('.wrapDiscount__As8_S__fast_order').text()) || 0;
@@ -202,7 +202,18 @@ define([
         const discountAmt = price * (discount / 100);
         const total = price - discountAmt;
 
-        const formatted = `Rs ${total.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        // Custom formatting for Indian Rupees to ensure correct decimal and thousand separators
+        const formatIndianCurrency = (amount) => {
+            // Fix to 2 decimal places
+            const fixedAmount = amount.toFixed(2);
+            // Split into integer and decimal parts
+            const [integerPart, decimalPart] = fixedAmount.split('.');
+            // Add commas as thousand separators (Indian number system)
+            const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+            return `Rs ${formattedInteger}.${decimalPart}`;
+        };
+
+        const formatted = formatIndianCurrency(total);
         $row.find('.wrapSubTotal__3x0vV__fast_order').html(formatted);
     }
 

--- a/FastOrder/view/frontend/web/js/quickview.js
+++ b/FastOrder/view/frontend/web/js/quickview.js
@@ -157,11 +157,13 @@
             },
             formatCurrency: function (t) {
                if (this.currencyCode) {
-                  var e = f.a.getLocales(this.currencyCode)[0];
-                  return new Intl.NumberFormat(e, {
-                     style: "currency",
-                     currency: this.currencyCode
-                  }).format(t)
+                  // Custom formatting for Indian Rupees to ensure correct decimal and thousand separators
+                  var fixedAmount = t.toFixed(2);
+                  var parts = fixedAmount.split('.');
+                  var integerPart = parts[0];
+                  var decimalPart = parts[1];
+                  var formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+                  return 'Rs ' + formattedInteger + '.' + decimalPart;
                }
             }
          },

--- a/view/frontend/web/js/enhanced-product-ui.js
+++ b/view/frontend/web/js/enhanced-product-ui.js
@@ -193,7 +193,7 @@ define([
         });
     }
 
-    function updateRowSubtotal($row) {
+        function updateRowSubtotal($row) {
         const qty = parseFloat($row.find('input[type="number"]').val()) || 0;
         const ptr = parseFloat($row.find('.wrapPtr__As8_S__fast_order').text()) || 0;
         const discount = parseFloat($row.find('.wrapDiscount__As8_S__fast_order').text()) || 0;
@@ -202,7 +202,18 @@ define([
         const discountAmt = price * (discount / 100);
         const total = price - discountAmt;
 
-        const formatted = `Rs ${total.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        // Custom formatting for Indian Rupees to ensure correct decimal and thousand separators
+        const formatIndianCurrency = (amount) => {
+            // Fix to 2 decimal places
+            const fixedAmount = amount.toFixed(2);
+            // Split into integer and decimal parts
+            const [integerPart, decimalPart] = fixedAmount.split('.');
+            // Add commas as thousand separators (Indian number system)
+            const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+            return `Rs ${formattedInteger}.${decimalPart}`;
+        };
+
+        const formatted = formatIndianCurrency(total);
         $row.find('.wrapSubTotal__3x0vV__fast_order').html(formatted);
     }
 

--- a/view/frontend/web/js/quickview.js
+++ b/view/frontend/web/js/quickview.js
@@ -157,11 +157,13 @@
             },
             formatCurrency: function (t) {
                if (this.currencyCode) {
-                  var e = f.a.getLocales(this.currencyCode)[0];
-                  return new Intl.NumberFormat(e, {
-                     style: "currency",
-                     currency: this.currencyCode
-                  }).format(t)
+                  // Custom formatting for Indian Rupees to ensure correct decimal and thousand separators
+                  var fixedAmount = t.toFixed(2);
+                  var parts = fixedAmount.split('.');
+                  var integerPart = parts[0];
+                  var decimalPart = parts[1];
+                  var formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+                  return 'Rs ' + formattedInteger + '.' + decimalPart;
                }
             }
          },


### PR DESCRIPTION
Fix Indian Rupee currency formatting to use commas for thousands and periods for decimals.

The default `toLocaleString` and `Intl.NumberFormat` methods were not consistently producing the required Indian Rupee format (e.g., `7.881,68` instead of `7,881.68`). This PR implements custom formatting logic to ensure correct decimal and thousand separators across the affected currency displays.